### PR TITLE
Updated code to include python3 read compatibility

### DIFF
--- a/pg_python/_read.py
+++ b/pg_python/_read.py
@@ -4,7 +4,7 @@ def make_postgres_read_statement(table, kv_map, keys_to_get, limit, order_by,
     _join_by = " " + join_clause + " "
     _table_string = " ".join(["FROM", table])
     _key_string = _join_by.join([k + clause + "%s" for k in kv_map.keys()])
-    values = kv_map.values()
+    values = list(kv_map.values())
 
     if clause.strip().lower() == "in":
         values = []


### PR DESCRIPTION
Updated code to include python3 read compatibility as dict.values() returns a view in python3 instead of a list. It now works when called from a python3 codebase.