### PR TITLE
Adding a 'port' parameter to pg_server() function

### DIFF
--- a/pg_python/pg_crawler.py
+++ b/pg_python/pg_crawler.py
@@ -17,13 +17,14 @@ print_debug_log = True
 params_map = {}
 
 
-def pg_server(db_name, username, password, host_address, debug=True, send_keep_alive_probes=False, socket_idle_time=120):
+def pg_server(db_name, username, password, host_address, port: int = 5432, debug=True, send_keep_alive_probes=False, socket_idle_time=120):
   global crawler_db, print_debug_log, params_map
   params_map = {
     'dbname': db_name,
     'user': username,
     'password': password,
     'host': host_address,
+    'port': port,
     'send_keep_alive_probes': send_keep_alive_probes,
     'socket_idle_time': socket_idle_time,
     }

--- a/pg_python/pg_local.py
+++ b/pg_python/pg_local.py
@@ -16,13 +16,14 @@ print_debug_log = True
 params_map = {}
 
 
-def pg_server(db_name, username, password, host_address, debug=True, send_keep_alive_probes=False, socket_idle_time=120):
+def pg_server(db_name, username, password, host_address, port: int = 5432, debug=True, send_keep_alive_probes=False, socket_idle_time=120):
   global local_db, print_debug_log, params_map
   params_map = {
     'dbname': db_name,
     'user': username,
     'password': password,
     'host': host_address,
+    'port': port,
     'send_keep_alive_probes': send_keep_alive_probes,
     'socket_idle_time': socket_idle_time,
     }

--- a/pg_python/pg_python.py
+++ b/pg_python/pg_python.py
@@ -62,7 +62,7 @@ def server_connection_check(func):
     return wrapper
 
 
-def pg_server(db_name, username, password, host_address, debug=True, server="default", send_keep_alive_probes=False, socket_idle_time=120, application_name='pg_python'):
+def pg_server(db_name, username, password, host_address, port: int = 5432, debug=True, server="default", send_keep_alive_probes=False, socket_idle_time=120, application_name='pg_python'):
     global print_debug_log
     # no need to make socket so, send_keep_alive_probes will no longer usefull
     params_map = {
@@ -70,6 +70,7 @@ def pg_server(db_name, username, password, host_address, debug=True, server="def
         'user'    : username,
         'password': password,
         'host'    : host_address,
+        'port'    : port,
         'application_name': application_name
     }
     db_obj = Db(params_map)


### PR DESCRIPTION
Changes are made for the pg_server() function in pg_crawler.py pg_local.py and pg_python.py